### PR TITLE
[as2_platform_crazyflie] Add missing docstrings in header files

### DIFF
--- a/include/as2_platform_crazyflie/crazyflie_platform.hpp
+++ b/include/as2_platform_crazyflie/crazyflie_platform.hpp
@@ -101,33 +101,141 @@ class CrazyfliePlatform : public as2::AerialPlatform
   std::string odom_frame_;
 
 public:
+  /**
+   * @brief Connect to the Crazyflie, start its log blocks and create the
+   * publishers, subscriptions and timers of the platform.
+   */
   void init();
+
+  /**
+   * @brief Construct the Crazyflie platform with the default namespace and the
+   * radio uri taken from the uri parameter.
+   */
   CrazyfliePlatform();
+
+  /**
+   * @brief Construct the Crazyflie platform in a given namespace.
+   *
+   * @param ns Namespace of the drone.
+   */
   explicit CrazyfliePlatform(const std::string & ns);
+
+  /**
+   * @brief Construct the Crazyflie platform in a given namespace, overriding
+   * the radio uri.
+   *
+   * @param ns Namespace of the drone.
+   * @param radio_uri Crazyradio uri of the vehicle.
+   */
   explicit CrazyfliePlatform(const std::string & ns, const std::string & radio_uri);
+
+  /**
+   * @brief Declare and read the platform parameters.
+   *
+   * @param radio_uri Unused. The uri is read from the uri parameter.
+   */
   void configureParams(const std::string & radio_uri = "");
 
   /*  --  AS2 FUNCTIONS --  */
 
   void configureSensors() override;
 
+  /**
+   * @brief Arm or disarm the vehicle.
+   *
+   * @param state True to arm, false to disarm.
+   * @return true if the vehicle accepted the request.
+   */
   bool ownSetArmingState(bool state) override;
+  /**
+   * @brief Enter or leave offboard control.
+   *
+   * @param offboard True to take control, false to release it.
+   * @return true if the vehicle accepted the request.
+   */
   bool ownSetOffboardControl(bool offboard) override;
+  /**
+   * @brief Accept a control mode requested through the platform interface.
+   *
+   * @param msg Requested control mode.
+   * @return true if the platform accepts the mode.
+   */
   bool ownSetPlatformControlMode(const as2_msgs::msg::ControlMode & msg) override;
+  /**
+   * @brief Send the current actuator commands to the vehicle.
+   *
+   * @return true if the command was sent.
+   */
   bool ownSendCommand() override;
+  /**
+   * @brief Stop the motors immediately, without landing.
+   */
   void ownKillSwitch() override {cf_->emergencyStop();}
+  /**
+   * @brief Hold the vehicle in place with a zero setpoint.
+   */
   void ownStopPlatform() override {cf_->sendStop();}
 
   /*  --  CRAZYFLIE FUNCTIONS --  */
 
+  /**
+   * @brief Log the variables the connected Crazyflie exposes, for debugging.
+   */
   void listVariables();
+
+  /**
+   * @brief Poll the radio link, dispatching the pending log packets.
+   */
   void pingCB();
+
+  /**
+   * @brief Publish the IMU measurement of a gyro and accelerometer log packet.
+   *
+   * @param time_in_ms Timestamp of the packet, in ms since the vehicle booted.
+   * @param values {gyro.x, gyro.y, gyro.z, acc.x, acc.y, acc.z}.
+   */
   void onLogIMU(uint32_t time_in_ms, std::vector<double> * values, void * /*userData*/);
+
+  /**
+   * @brief Store the orientation of an odometry log packet.
+   *
+   * @param time_in_ms Timestamp of the packet, in ms since the vehicle booted.
+   * @param values Roll, pitch and yaw of the vehicle.
+   */
   void onLogOdomOri(uint32_t time_in_ms, std::vector<double> * values, void * /*userData*/);
+
+  /**
+   * @brief Store the position of an odometry log packet and publish the odometry.
+   *
+   * @param time_in_ms Timestamp of the packet, in ms since the vehicle booted.
+   * @param values Position and linear velocity of the vehicle.
+   */
   void onLogOdomPos(uint32_t time_in_ms, std::vector<double> * values, void * /*userData*/);
+
+  /**
+   * @brief Publish the battery level read from the vehicle.
+   */
   void onLogBattery();
+
+  /**
+   * @brief Publish the measurement of a range deck log packet.
+   *
+   * @param time_in_ms Timestamp of the packet, in ms since the vehicle booted.
+   * @param values Ranges of the multiranger deck.
+   */
   void onLogRange(uint32_t time_in_ms, std::vector<double> * values, void * /*userData*/);
+
+  /**
+   * @brief Publish the odometry built from the last stored position and
+   * orientation log packets.
+   */
   void updateOdom();
+
+  /**
+   * @brief Forward an external pose estimate to the Crazyflie estimator.
+   *
+   * @param msg Pose of the vehicle, from an external localization system.
+   */
   void externalOdomCB(const geometry_msgs::msg::PoseStamped::SharedPtr msg);
 
   /*  --  AUX FUNCTIONS --  */

--- a/src/crazyflie_platform.cpp
+++ b/src/crazyflie_platform.cpp
@@ -69,8 +69,7 @@
 
 void CrazyfliePlatform::configureParams(const std::string & radio_uri)
 {
-  this->declare_parameter<std::string>("uri", "radio://0/80/250K/E7E7E7E7E7");
-  this->get_parameter("uri", uri_);
+  uri_ = this->getParameter<std::string>("uri", "radio://0/80/250K/E7E7E7E7E7");
 }
 
 void CrazyfliePlatform::init()
@@ -79,8 +78,8 @@ void CrazyfliePlatform::init()
   odom_frame_ = as2::tf::generateTfName(this, "odom");
 
   /*    PARAMETERS    */
-  this->declare_parameter<bool>("multi_ranger_deck", false);  // Availability of multi-ranger deck
-  this->get_parameter("multi_ranger_deck", enable_multiranger_);
+  // Availability of multi-ranger deck
+  enable_multiranger_ = this->getParameter<bool>("multi_ranger_deck", false);
 
   configureSensors();
   /*    SET-UP    */
@@ -101,15 +100,13 @@ void CrazyfliePlatform::init()
   listVariables();
 
   /*    CONFIGURATION    */
-  this->declare_parameter<uint8_t>(
-    "controller_type",
-    1);                                 // Any(0), PID(1), Mellinger(2), INDI(3)
-  this->get_parameter("controller_type", controller_type_);
+  // Any(0), PID(1), Mellinger(2), INDI(3)
+  controller_type_ = this->getParameter<uint8_t>("controller_type", 1);
   if (controller_type_ < 0 || controller_type_ > 3) {controller_type_ = 1;}
   cf_->setParamByName<uint8_t>("stabilizer", "controller", (uint8_t)(controller_type_));
 
-  this->declare_parameter<uint8_t>("estimator_type", 2);  // Any(0), Complementary(1), EKF(2)
-  this->get_parameter("estimator_type", estimator_type_);
+  // Any(0), Complementary(1), EKF(2)
+  estimator_type_ = this->getParameter<uint8_t>("estimator_type", 2);
   if (estimator_type_ < 0 || estimator_type_ > 2) {estimator_type_ = 2;}
   cf_->setParamByName<uint8_t>("stabilizer", "estimator", (uint8_t)(estimator_type_));  // EKF
 
@@ -162,10 +159,8 @@ void CrazyfliePlatform::init()
   }
 
   // External estimation
-  this->declare_parameter<bool>("external_odom", false);
-  this->get_parameter("external_odom", external_odom_);
-  this->declare_parameter<std::string>("external_odom_topic", "external_odom");
-  this->get_parameter("external_odom_topic", external_odom_topic_);
+  external_odom_ = this->getParameter<bool>("external_odom", false);
+  external_odom_topic_ = this->getParameter<std::string>("external_odom_topic", "external_odom");
 
   // If using external localization, create the subscriber to it
   if (external_odom_) {


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Crazyflie |

---

## Description of contribution in a few bullet points

* Adds doxygen docstrings to every public method of `crazyflie_platform.hpp` that was missing one. **Documentation only: no declaration, signature or behaviour changes.**
* Companion of aerostack2/aerostack2#985, which does the same across the aerostack2 packages.
