### PR TITLE
[as2_platform_crazyflie] Read the canonical robot frames from as2::Node

### DIFF
--- a/src/crazyflie_platform.cpp
+++ b/src/crazyflie_platform.cpp
@@ -74,8 +74,8 @@ void CrazyfliePlatform::configureParams(const std::string & radio_uri)
 
 void CrazyfliePlatform::init()
 {
-  base_frame_ = as2::tf::generateTfName(this, "base_link");
-  odom_frame_ = as2::tf::generateTfName(this, "odom");
+  base_frame_ = this->getBaseFrameId();
+  odom_frame_ = this->getOdomFrameId();
 
   /*    PARAMETERS    */
   // Availability of multi-ranger deck


### PR DESCRIPTION
Asks `as2::Node` for the canonical robot frames instead of building them from string literals.

The four frames every robot has — the global one, the map, the local odometry frame and the body — are declared once by `as2::Node` and namespaced there, so naming a frame in the robot config reaches every node. This package built its own, which no parameter could change.

Depends on https://github.com/aerostack2/aerostack2/pull/989, which has to be merged first.