### PR TITLE
[as2_platform_crazyflie] Declare the frames of the platform commands

### DIFF
--- a/config/control_modes.yaml
+++ b/config/control_modes.yaml
@@ -6,7 +6,7 @@
 #
 # unset             = 0 = 0b0000
 # hover             = 1 = 0b0001
-# acro              = 2 = 0b0010
+# body_rates        = 2 = 0b0010
 # attitude          = 3 = 0b0011
 # speed             = 4 = 0b0100
 # speed_in_a_plane  = 5 = 0b0101
@@ -29,7 +29,7 @@
 available_modes:
   - 0b00000000 # UNSET
   # - 0b00010000 # HOVER
-  # - 0b00100100 # ACRO (p,q,r, Thrust)
+  # - 0b00100100 # BODY_RATES (p,q,r, Thrust)
   # - 0b00110001 # ATTITUDE with yaw ANGLE ( r,p,y , Thrust) 
   # - 0b00110101 # ATTITUDE with yaw SPEED ( r,p, dy , Thrust) 
   # - 0b01000000 # SPEED with yaw ANGLE in the LOCAL_FLU_FRAME

--- a/config/control_modes.yaml
+++ b/config/control_modes.yaml
@@ -1,6 +1,6 @@
 #----------------------------------------------------------------
 # A complete control mode is an 8 bits flag 
-# (4bits control mode + 2 yaw mode bits + 2 reference frame bits)
+# (4bits control mode + 2 yaw mode bits + 2 reserved bits)
 #
 # ------------- mode codification (4 bits) ----------------------
 #
@@ -18,11 +18,7 @@
 # angle             = 0 = 0b00
 # speed             = 1 = 0b01
 # 
-# frame codification
-# 
-# local_frame_flu   = 0 = 0b00
-# global_frame_enu  = 1 = 0b01
-# global_frame_lla  = 2 = 0b10
+# Bits [1:0] are reserved and ignored
 # 
 #-----------------------------------------------------------------
 
@@ -30,17 +26,13 @@ available_modes:
   - 0b00000000 # UNSET
   # - 0b00010000 # HOVER
   # - 0b00100100 # BODY_RATES (p,q,r, Thrust)
-  # - 0b00110001 # ATTITUDE with yaw ANGLE ( r,p,y , Thrust) 
-  # - 0b00110101 # ATTITUDE with yaw SPEED ( r,p, dy , Thrust) 
-  # - 0b01000000 # SPEED with yaw ANGLE in the LOCAL_FLU_FRAME
-  # - 0b01000001 # SPEED with yaw ANGLE in the GLOBAL_ENU_FRAME
-  # - 0b01000100 # SPEED with yaw SPEED in the LOCAL_FLU_FRAME
-  - 0b01000101 # SPEED with yaw SPEED in the GLOBAL_ENU_FRAME
-  # - 0b01010000 # SPEED_IN_A_PLANE with yaw ANGLE in the LOCAL_FLU_FRAME
-  # - 0b01010001 # SPEED_IN_A_PLANE with yaw ANGLE in the GLOBAL_ENU_FRAME
-  # - 0b01010100 # SPEED_IN_A_PLANE with yaw SPEED in the LOCAL_FLU_FRAME
-  - 0b01010101 # SPEED_IN_A_PLANE with yaw SPEED in the GLOBAL_ENU_FRAME
-  # - 0b01100001 # POSITION with yaw ANGLE in the GLOBAL_ENU_FRAME
-  # - 0b01100101 # POSITION with yaw SPEED in the GLOBAL_ENU_FRAME
-  # - 0b01110001 # TRAJECTORY with yaw ANGLE in the GLOBAL_ENU_FRAME
-  # - 0b01110101 # TRAJECTORY with yaw SPEED in the GLOBAL_ENU_FRAME
+  # - 0b00110000 # ATTITUDE with yaw ANGLE ( r,p,y , Thrust)
+  # - 0b00110100 # ATTITUDE with yaw SPEED ( r,p, dy , Thrust)
+  # - 0b01000000 # SPEED with yaw ANGLE
+  - 0b01000100 # SPEED with yaw SPEED
+  # - 0b01010000 # SPEED_IN_A_PLANE with yaw ANGLE
+  - 0b01010100 # SPEED_IN_A_PLANE with yaw SPEED
+  # - 0b01100000 # POSITION with yaw ANGLE
+  # - 0b01100100 # POSITION with yaw SPEED
+  # - 0b01110000 # TRAJECTORY with yaw ANGLE
+  # - 0b01110100 # TRAJECTORY with yaw SPEED

--- a/include/as2_platform_crazyflie/crazyflie_platform.hpp
+++ b/include/as2_platform_crazyflie/crazyflie_platform.hpp
@@ -96,7 +96,6 @@ struct logBattery
 
 class CrazyfliePlatform : public as2::AerialPlatform
 {
-  as2::tf::TfHandler tf_handler_;
   std::string base_frame_;
   std::string odom_frame_;
 

--- a/src/crazyflie_platform.cpp
+++ b/src/crazyflie_platform.cpp
@@ -179,7 +179,7 @@ void CrazyfliePlatform::init()
 }
 
 CrazyfliePlatform::CrazyfliePlatform()
-: as2::AerialPlatform(), tf_handler_(this)
+: as2::AerialPlatform()
 {
   RCLCPP_INFO(this->get_logger(), "CrazyfliePlatform::CrazyfliePlatform");
   configureParams();
@@ -187,14 +187,14 @@ CrazyfliePlatform::CrazyfliePlatform()
 }
 
 CrazyfliePlatform::CrazyfliePlatform(const std::string & ns)
-: as2::AerialPlatform(ns), tf_handler_(this)
+: as2::AerialPlatform(ns)
 {
   configureParams();
   init();
 }
 
 CrazyfliePlatform::CrazyfliePlatform(const std::string & ns, const std::string & radio_uri)
-: as2::AerialPlatform(ns), uri_(radio_uri), tf_handler_(this)
+: as2::AerialPlatform(ns), uri_(radio_uri)
 {
   RCLCPP_INFO(
     get_logger(), "CrazyfliePlatform constructor with ns[%s] and uri[%s]", ns.c_str(),
@@ -387,15 +387,7 @@ bool CrazyfliePlatform::ownSendCommand()
   const double yaw       = (eulerAngles[2] / 3.1416 * 180.0); */
   // this->command_twist_msg_.header.frame_id = "earth";
 
-  // bool out = tf_handler_.tryConvert(this->command_twist_msg_, odom_frame_);
-
-  // if (!out) {
-  //   RCLCPP_ERROR(this->get_logger(), "Could not convert command to odom frame");
-  //   return false;
-  // }
-
   if (platform_control_mode.yaw_mode == as2_msgs::msg::ControlMode::YAW_SPEED &&
-    platform_control_mode.reference_frame == as2_msgs::msg::ControlMode::LOCAL_ENU_FRAME &&
     this->getArmingState() && is_connected_)
   {
     switch (platform_control_mode.control_mode) {
@@ -462,10 +454,12 @@ bool CrazyfliePlatform::ownSetOffboardControl(bool offboard) {return is_connecte
 
 bool CrazyfliePlatform::ownSetPlatformControlMode(const as2_msgs::msg::ControlMode & msg)
 {
-  // Only the yaw speed modes implemented with ENU reference.
-  if (msg.yaw_mode == as2_msgs::msg::ControlMode::YAW_SPEED &&
-    msg.reference_frame == as2_msgs::msg::ControlMode::LOCAL_ENU_FRAME)
-  {
+  // The crazyflie setpoints are expressed in the local reference frame
+  setCommandPoseFrameId(odom_frame_);
+  setCommandTwistFrameId(odom_frame_);
+
+  // Only the yaw speed modes implemented.
+  if (msg.yaw_mode == as2_msgs::msg::ControlMode::YAW_SPEED) {
     switch (msg.control_mode) {
       case as2_msgs::msg::ControlMode::SPEED:
 
@@ -559,7 +553,7 @@ void CrazyfliePlatform::externalOdomCB(const geometry_msgs::msg::PoseStamped::Sh
   try {
     // pose obtained in odom frame to avoid yaw issues
     // auto pose = tf_handler.getPoseStamped(odom_frame, base_frame);
-    auto pose = tf_handler_.getPoseStamped(odom_frame_, base_frame_);
+    auto pose = tf_handler_->getPoseStamped(odom_frame_, base_frame_);
 
     // RCLCPP_INFO(get_logger(), " %f, %f, %f ", pose.pose.position.x, pose.pose.position.y,
     //             pose.pose.position.z);


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses   | — |
| ROS2 version tested on | Humble |
| Aerial platform tested on | Not flown, builds and tests only |

---

## Description of contribution in a few bullet points

* **The platform declares the frames of its commands.** It names, per control
  mode, the TF frame it wants each command in, and the base class converts them
  before handing them over. The reference frame of the control mode is gone, so
  the platform no longer reads it, and the modes that only differed by frame
  collapse into one.

* **`ACRO` is renamed to `BODY_RATES`.** It was named after a flight mode of one
  autopilot, while every other mode is named after the quantity it commands.

Depends on #13, which has to be merged first, and on aerostack2/aerostack2#990.
